### PR TITLE
Feat：管理者画面の大枠を作成

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,9 @@ services:
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails server -b '0.0.0.0'"
 
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.dev
     volumes:
       - ./frontend:/app
       - /app/node_modules

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,14 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Yarn v3を使用
+RUN corepack enable && corepack prepare yarn@3.6.4 --activate
+
+COPY package.json yarn.lock ./
+RUN yarn config set nodeLinker node-modules && yarn install --frozen-lockfile
+
+EXPOSE 5173
+
+# Vite development server
+CMD ["yarn", "dev", "--host", "0.0.0.0", "--port", "5173"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@heroicons/react": "^2",
     "axios": "^1.9.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -1,14 +1,8 @@
 import React from 'react'
-import { BaseProps } from '../types'
+import AdminDashboard from './AdminDashboard'
 
-const Admin: React.FC<BaseProps> = ({ basePath }) => {
-  return (
-    <div className="p-10">
-      <h2>管理画面（仮）</h2>
-      <p>ここに管理機能を実装します。</p>
-      <p>スラッグ: {basePath}</p>
-    </div>
-  )
+const Admin: React.FC = () => {
+  return <AdminDashboard />
 }
 
 export default Admin

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -1,0 +1,237 @@
+import React, { useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+
+interface MenuItem {
+  id: string
+  label: string
+  icon: string
+  description: string
+}
+
+const menuItems: MenuItem[] = [
+  {
+    id: 'overview',
+    label: 'ダッシュボード',
+    icon: '🏠',
+    description: 'アクセス状況や診断数などの概要を確認',
+  },
+  {
+    id: 'page-design',
+    label: 'ページ・デザイン管理',
+    icon: '🎨',
+    description: 'ナビゲーションやCTAボタンのカスタマイズ',
+  },
+  {
+    id: 'account',
+    label: 'アカウント情報管理',
+    icon: '⚙️',
+    description: '組織情報やロゴの設定',
+  },
+  {
+    id: 'events',
+    label: '会員向けイベント',
+    icon: '📅',
+    description: 'イベントの作成・管理',
+  },
+  {
+    id: 'analytics',
+    label: 'アクセス分析',
+    icon: '📊',
+    description: 'ページビューや診断完了数の確認',
+  },
+  {
+    id: 'members',
+    label: '会員管理',
+    icon: '👥',
+    description: 'スタッフアカウントの権限管理',
+  },
+]
+
+const AdminDashboard: React.FC = () => {
+  const { slug } = useParams<{ slug: string }>()
+  const navigate = useNavigate()
+  const [selectedMenu, setSelectedMenu] = useState('overview')
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false)
+
+  const handleMenuClick = (menuId: string) => {
+    setSelectedMenu(menuId)
+    setIsSidebarOpen(false)
+  }
+
+  const renderContent = () => {
+    const currentItem = menuItems.find((item) => item.id === selectedMenu)
+
+    switch (selectedMenu) {
+      case 'overview':
+        return (
+          <div className="space-y-6">
+            <div className="bg-white rounded-lg shadow p-6">
+              <h3 className="text-lg font-semibold mb-4">今日の概要</h3>
+              <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                <div className="bg-blue-50 rounded-lg p-4">
+                  <p className="text-sm text-gray-600">ページビュー</p>
+                  <p className="text-2xl font-bold text-blue-600">1,234</p>
+                  <p className="text-xs text-gray-500">前日比 +12%</p>
+                </div>
+                <div className="bg-green-50 rounded-lg p-4">
+                  <p className="text-sm text-gray-600">診断完了数</p>
+                  <p className="text-2xl font-bold text-green-600">89</p>
+                  <p className="text-xs text-gray-500">前日比 +5%</p>
+                </div>
+                <div className="bg-purple-50 rounded-lg p-4">
+                  <p className="text-sm text-gray-600">CTAクリック数</p>
+                  <p className="text-2xl font-bold text-purple-600">45</p>
+                  <p className="text-xs text-gray-500">前日比 +8%</p>
+                </div>
+                <div className="bg-orange-50 rounded-lg p-4">
+                  <p className="text-sm text-gray-600">イベント参加者</p>
+                  <p className="text-2xl font-bold text-orange-600">23</p>
+                  <p className="text-xs text-gray-500">次回: 12/25</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow p-6">
+              <h3 className="text-lg font-semibold mb-4">最近の活動</h3>
+              <div className="space-y-3">
+                <div className="flex items-center space-x-3 text-sm">
+                  <span className="text-gray-500">10:30</span>
+                  <span>新規診断完了: 女性 / タイプA</span>
+                </div>
+                <div className="flex items-center space-x-3 text-sm">
+                  <span className="text-gray-500">09:45</span>
+                  <span>イベント申込: 「婚活パーティー」に1名参加</span>
+                </div>
+                <div className="flex items-center space-x-3 text-sm">
+                  <span className="text-gray-500">09:15</span>
+                  <span>CTAボタンクリック: 「無料相談予約」</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        )
+
+      default:
+        return (
+          <div className="bg-white rounded-lg shadow p-8">
+            <div className="flex items-center space-x-4 mb-6">
+              {currentItem && (
+                <>
+                  <span className="text-3xl">{currentItem.icon}</span>
+                  <div>
+                    <h3 className="text-xl font-semibold">{currentItem.label}</h3>
+                    <p className="text-sm text-gray-500">
+                      {currentItem.description}
+                    </p>
+                  </div>
+                </>
+              )}
+            </div>
+            <div className="bg-gray-50 rounded-lg p-12 text-center">
+              <p className="text-gray-500">
+                この機能は現在開発中です。
+                <br />
+                まもなく利用可能になります。
+              </p>
+            </div>
+          </div>
+        )
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* モバイル用メニューボタン */}
+      <div className="lg:hidden fixed top-4 left-4 z-50">
+        <button
+          onClick={() => setIsSidebarOpen(!isSidebarOpen)}
+          className="bg-white p-2 rounded-md shadow-lg"
+        >
+          <span className="text-xl">{isSidebarOpen ? '✕' : '☰'}</span>
+        </button>
+      </div>
+
+      {/* サイドバー */}
+      <div
+        className={`fixed inset-y-0 left-0 z-40 w-64 bg-white shadow-lg transform transition-transform duration-300 ease-in-out ${
+          isSidebarOpen ? 'translate-x-0' : '-translate-x-full'
+        } lg:translate-x-0`}
+      >
+        <div className="h-full flex flex-col">
+          {/* ロゴ・組織名 */}
+          <div className="p-6 border-b">
+            <h1 className="text-xl font-bold text-gray-800">相談所管理画面</h1>
+            <p className="text-sm text-gray-500 mt-1">{slug}</p>
+          </div>
+
+          {/* メニューアイテム */}
+          <nav className="flex-1 overflow-y-auto p-4">
+            <ul className="space-y-2">
+              {menuItems.map((item) => {
+                const isSelected = selectedMenu === item.id
+                return (
+                  <li key={item.id}>
+                    <button
+                      onClick={() => handleMenuClick(item.id)}
+                      className={`w-full flex items-center justify-between p-3 rounded-lg transition-colors duration-200 ${
+                        isSelected
+                          ? 'bg-blue-50 text-blue-600'
+                          : 'hover:bg-gray-100 text-gray-700'
+                      }`}
+                    >
+                      <div className="flex items-center space-x-3">
+                        <span className="text-xl">{item.icon}</span>
+                        <span className="font-medium">{item.label}</span>
+                      </div>
+                      {isSelected && (
+                        <span className="text-sm">▶</span>
+                      )}
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          </nav>
+
+          {/* サイトプレビューボタン */}
+          <div className="px-4 py-4 border-t">
+            <button
+              onClick={() => window.open(`/${slug}`, '_blank')}
+              className="w-full py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors duration-200 text-sm font-medium flex items-center justify-center space-x-2"
+            >
+              <span>🔗</span>
+              <span>プレビュー</span>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* メインコンテンツ */}
+      <div className="lg:ml-64">
+        <div className="p-6 lg:p-8">
+          <div className="max-w-7xl mx-auto">
+            {/* ヘッダー */}
+            <div className="mb-8">
+              <h2 className="text-2xl lg:text-3xl font-bold text-gray-800">
+                {menuItems.find((item) => item.id === selectedMenu)?.label}
+              </h2>
+            </div>
+
+            {/* コンテンツ */}
+            {renderContent()}
+          </div>
+        </div>
+      </div>
+
+      {/* モバイル用オーバーレイ */}
+      {isSidebarOpen && (
+        <div
+          className="lg:hidden fixed inset-0 bg-black bg-opacity-50 z-30"
+          onClick={() => setIsSidebarOpen(false)}
+        />
+      )}
+    </div>
+  )
+}
+
+export default AdminDashboard

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -468,6 +468,11 @@
     "@eslint/core" "^0.15.1"
     levn "^0.4.1"
 
+"@heroicons/react@^2":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-2.2.0.tgz#0c05124af50434a800773abec8d3af6a297d904b"
+  integrity sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==
+
 "@humanfs/core@^0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.1.tgz#17c55ca7d426733fe3c561906b8173c336b40a77"


### PR DESCRIPTION
## 概要

管理者画面の大枠を作った。実際の動作する機能は別PRにて上げる予定。

## 変更内容

具体的には以下の項目を表示

・概要
・ページ・デザイン管理
・アカウント情報管理
・会員向けイベント
・アクセス分析
・スタッフ権限管理

<img width="1435" height="810" alt="スクリーンショット 2025-08-29 0 30 00" src="https://github.com/user-attachments/assets/ff862770-0387-40e3-b5b9-74f4f3cc6734" />
