### PR TITLE
Feat：別組織へのログインを防止

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -38,6 +38,9 @@ gem "rack-cors"
 # Authentication
 gem "devise"
 
+# Multi-tenancy
+gem "acts_as_tenant"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    acts_as_tenant (1.0.1)
+      rails (>= 6.0)
     ast (2.4.3)
     base64 (0.2.0)
     bcrypt (3.1.20)
@@ -316,6 +318,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  acts_as_tenant
   bootsnap
   brakeman
   debug

--- a/backend/app/controllers/api/v1/sessions_controller.rb
+++ b/backend/app/controllers/api/v1/sessions_controller.rb
@@ -4,7 +4,7 @@ module Api
       def create
         # テナントスラッグが必須
         tenant = Tenant.find_by(slug: params[:tenant_slug])
-        
+
         unless tenant
           return render json: {
             status: "error",

--- a/backend/app/controllers/api/v1/sessions_controller.rb
+++ b/backend/app/controllers/api/v1/sessions_controller.rb
@@ -2,35 +2,48 @@ module Api
   module V1
     class SessionsController < ApplicationController
       def create
-        user = User.find_by(email: params[:email])
-
-        if user && user.valid_password?(params[:password])
-          # セッショントークンを生成
-          token = SecureRandom.hex(20)
-
-          # トークンと有効期限をユーザーに保存（24時間後に期限切れ）
-          user.update(
-            authentication_token: token,
-            token_expires_at: 24.hours.from_now
-          )
-
-          render json: {
-            status: "success",
-            data: {
-              user: {
-                id: user.id,
-                email: user.email,
-                name: user.name,
-                tenant_slug: user.tenant.slug
-              },
-              token: token
-            }
-          }, status: :ok
-        else
-          render json: {
+        # テナントスラッグが必須
+        tenant = Tenant.find_by(slug: params[:tenant_slug])
+        
+        unless tenant
+          return render json: {
             status: "error",
-            message: "メールアドレスまたはパスワードが正しくありません"
-          }, status: :unauthorized
+            message: "相談所が見つかりません"
+          }, status: :not_found
+        end
+
+        # テナント内でのみユーザーを検索
+        ActsAsTenant.with_tenant(tenant) do
+          user = User.find_by(email: params[:email])
+
+          if user && user.valid_password?(params[:password])
+            # セッショントークンを生成
+            token = SecureRandom.hex(20)
+
+            # トークンと有効期限をユーザーに保存（24時間後に期限切れ）
+            user.update(
+              authentication_token: token,
+              token_expires_at: 24.hours.from_now
+            )
+
+            render json: {
+              status: "success",
+              data: {
+                user: {
+                  id: user.id,
+                  email: user.email,
+                  name: user.name,
+                  tenant_slug: user.tenant.slug
+                },
+                token: token
+              }
+            }, status: :ok
+          else
+            render json: {
+              status: "error",
+              message: "メールアドレスまたはパスワードが正しくありません"
+            }, status: :unauthorized
+          end
         end
       end
 

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   belongs_to :tenant
+  acts_as_tenant(:tenant)
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -42,7 +42,8 @@ Rails.application.routes.draw do
           post :bulk_update
         end
       end
-      post "/sessions", to: "sessions#create"
+      # ログインはテナントスラッグ必須
+      post "/tenants/:tenant_slug/sessions", to: "sessions#create"
       delete "/sessions", to: "sessions#destroy"
       get "/sessions/validate", to: "sessions#validate"
       get "cta_buttons/index"

--- a/backend/spec/requests/api/v1/sessions_spec.rb
+++ b/backend/spec/requests/api/v1/sessions_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe "Api::V1::Sessions", type: :request do
-  let(:tenant) { create(:tenant) }
+  let(:tenant) { create(:tenant, slug: 'test-clinic') }
+  let(:other_tenant) { create(:tenant, slug: 'other-clinic') }
   let(:user) { create(:user, tenant: tenant, password: 'password123', password_confirmation: 'password123') }
+  let(:other_user) { create(:user, tenant: other_tenant, email: 'other@example.com', password: 'password456', password_confirmation: 'password456') }
   let(:valid_credentials) { { email: user.email, password: 'password123' } }
   let(:invalid_credentials) { { email: user.email, password: 'wrongpassword' } }
 
@@ -10,10 +12,10 @@ RSpec.describe "Api::V1::Sessions", type: :request do
     host! 'localhost'
   end
 
-  describe "POST /api/v1/sessions" do
+  describe "POST /api/v1/tenants/:tenant_slug/sessions" do
     context "with valid credentials" do
       it "creates a session and returns user data with token" do
-        post "/api/v1/sessions", params: valid_credentials
+        post "/api/v1/tenants/#{tenant.slug}/sessions", params: valid_credentials
 
         expect(response).to have_http_status(:ok)
         expect(response.content_type).to match(a_string_including("application/json"))
@@ -33,7 +35,7 @@ RSpec.describe "Api::V1::Sessions", type: :request do
 
       it "sets token expiration to 24 hours from now" do
         freeze_time do
-          post "/api/v1/sessions", params: valid_credentials
+          post "/api/v1/tenants/#{tenant.slug}/sessions", params: valid_credentials
 
           user.reload
           expect(user.token_expires_at).to be_within(1.second).of(24.hours.from_now)
@@ -43,7 +45,7 @@ RSpec.describe "Api::V1::Sessions", type: :request do
 
     context "with invalid credentials" do
       it "returns error for wrong password" do
-        post "/api/v1/sessions", params: invalid_credentials
+        post "/api/v1/tenants/#{tenant.slug}/sessions", params: invalid_credentials
 
         expect(response).to have_http_status(:unauthorized)
 
@@ -53,13 +55,51 @@ RSpec.describe "Api::V1::Sessions", type: :request do
       end
 
       it "returns error for non-existent user" do
-        post "/api/v1/sessions", params: { email: 'nonexistent@example.com', password: 'password123' }
+        post "/api/v1/tenants/#{tenant.slug}/sessions", params: { email: 'nonexistent@example.com', password: 'password123' }
 
         expect(response).to have_http_status(:unauthorized)
 
         json_response = JSON.parse(response.body)
         expect(json_response["status"]).to eq("error")
         expect(json_response["message"]).to eq("メールアドレスまたはパスワードが正しくありません")
+      end
+    end
+
+    context "with different tenant" do
+      it "rejects login attempt from user belonging to another tenant" do
+        post "/api/v1/tenants/#{other_tenant.slug}/sessions", params: { email: user.email, password: 'password123' }
+
+        expect(response).to have_http_status(:unauthorized)
+        json_response = JSON.parse(response.body)
+        expect(json_response["status"]).to eq("error")
+      end
+
+      it "returns not found for non-existent tenant" do
+        post "/api/v1/tenants/non-existent/sessions", params: valid_credentials
+
+        expect(response).to have_http_status(:not_found)
+        json_response = JSON.parse(response.body)
+        expect(json_response["status"]).to eq("error")
+        expect(json_response["message"]).to eq("相談所が見つかりません")
+      end
+    end
+
+    context "acts_as_tenant security" do
+      it "User model respects tenant scope" do
+        user
+        other_user
+
+        ActsAsTenant.with_tenant(tenant) do
+          expect(User.find_by(email: user.email)).to eq(user)
+          expect(User.find_by(email: other_user.email)).to be_nil
+          expect(User.count).to eq(1)
+        end
+
+        ActsAsTenant.with_tenant(other_tenant) do
+          expect(User.find_by(email: user.email)).to be_nil
+          expect(User.find_by(email: other_user.email)).to eq(other_user)
+          expect(User.count).to eq(1)
+        end
       end
     end
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres
+    image: postgres:17
     environment:
       POSTGRES_PASSWORD: password
     ports:

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -12,11 +12,13 @@ interface RegistrationData {
 interface LoginData {
   email: string
   password: string
+  tenant_slug: string
 }
 
 export const createInvitation = async (tenantData: {
   name: string
   slug: string
+  admin_email: string
 }) => {
   try {
     const response = await axios.post(`${API_BASE_URL}/invitations`, {
@@ -57,7 +59,11 @@ export const registerUser = async (token: string, data: RegistrationData) => {
 
 export const loginUser = async (data: LoginData) => {
   try {
-    const response = await axios.post(`${API_BASE_URL}/sessions`, data)
+    const { tenant_slug, ...loginData } = data
+    const response = await axios.post(
+      `${API_BASE_URL}/tenants/${tenant_slug}/sessions`,
+      loginData
+    )
     return response.data
   } catch (error) {
     if (axios.isAxiosError(error)) {

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -62,7 +62,7 @@ export const loginUser = async (data: LoginData) => {
     const { tenant_slug, ...loginData } = data
     const response = await axios.post(
       `${API_BASE_URL}/tenants/${tenant_slug}/sessions`,
-      loginData
+      loginData,
     )
     return response.data
   } catch (error) {

--- a/frontend/src/components/auth/InvitationForm.tsx
+++ b/frontend/src/components/auth/InvitationForm.tsx
@@ -11,6 +11,7 @@ export const InvitationForm: React.FC<InvitationFormProps> = ({
   const [formData, setFormData] = useState({
     name: '',
     slug: '',
+    admin_email: '',
   })
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
@@ -59,6 +60,25 @@ export const InvitationForm: React.FC<InvitationFormProps> = ({
             onChange={handleChange}
             required
             className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="admin_email"
+            className="block text-sm font-medium text-gray-700"
+          >
+            管理者メールアドレス
+          </label>
+          <input
+            type="email"
+            id="admin_email"
+            name="admin_email"
+            value={formData.admin_email}
+            onChange={handleChange}
+            required
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            placeholder="admin@example.com"
           />
         </div>
 

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { useParams } from 'react-router-dom'
 import { loginUser } from '../../api/auth'
 
 interface LoginFormProps {
@@ -6,6 +7,7 @@ interface LoginFormProps {
 }
 
 export const LoginForm: React.FC<LoginFormProps> = ({ onSuccess }) => {
+  const { slug } = useParams<{ slug: string }>()
   const [formData, setFormData] = useState({
     email: '',
     password: '',
@@ -18,8 +20,17 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onSuccess }) => {
     setError(null)
     setIsLoading(true)
 
+    if (!slug) {
+      setError('テナント情報が見つかりません。ページを再読み込みしてください。')
+      setIsLoading(false)
+      return
+    }
+
     try {
-      await loginUser(formData)
+      await loginUser({
+        ...formData,
+        tenant_slug: slug,
+      })
       onSuccess()
     } catch (err) {
       setError('ログインに失敗しました。')

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -20,7 +20,10 @@ const LoginPage: React.FC = () => {
     setIsLoading(true)
 
     try {
-      const response = await loginUser(formData)
+      const response = await loginUser({
+        ...formData,
+        tenant_slug: slug!,
+      })
       if (response.status === 'success') {
         login(response.data.user, response.data.token)
         navigate(`/${slug}/dashboard`)


### PR DESCRIPTION
## 概要
もともと組織に関係なく管理者がどの組織にでもログインできてしまう問題があったが、act_as_tenantを導入することでスラッグからテナントを絞り出しそこに所属する管理者かどうかの判定を加えることで別組織へのログインを防止するようにした。